### PR TITLE
Document contract versioning strategy and centralize config

### DIFF
--- a/CONTRACT_VERSIONS.md
+++ b/CONTRACT_VERSIONS.md
@@ -1,0 +1,117 @@
+# Contract Versioning Strategy
+
+## Current Deployed Contracts
+
+### Production (Mainnet)
+
+| Version | Contract Name | Address | Status | Deployment Date |
+|---------|---------------|---------|--------|----------------|
+| v1 | `sprintfund-core` | `SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T.sprintfund-core` | **ACTIVE** | Initial deployment |
+| v3 | `sprintfund-core-v3` | `SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T.sprintfund-core-v3` | Deployed | - |
+
+### Active Contract
+
+**The frontend and all production systems currently use:**
+- Contract: `SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T.sprintfund-core`
+- Network: Mainnet
+
+## Version Differences
+
+### v1 (sprintfund-core)
+- Initial production deployment
+- Core DAO functionality: proposals, voting, staking
+- Quadratic voting mechanism
+- Reputation tracking
+
+### v3 (sprintfund-core-v3)
+- Enhanced version with improvements
+- May include bug fixes or feature enhancements
+- **Note**: Currently deployed but not in active use by frontend
+
+## Versioning Strategy
+
+### 1. Semantic Contract Versioning
+
+Contract versions follow a simplified semantic versioning scheme:
+- **Major versions** (v1, v2, v3): Breaking changes requiring migration
+- **Deployment naming**: `sprintfund-core` (production), `sprintfund-core-v{N}` (newer versions)
+
+### 2. Version Migration Process
+
+When deploying a new contract version:
+
+1. **Deploy with version suffix**: Deploy as `sprintfund-core-v{N}`
+2. **Testing**: Test thoroughly on testnet and devnet
+3. **Documentation**: Document all changes in this file
+4. **Migration plan**: Create migration strategy for state/users
+5. **Update config**: Update `frontend/src/config.ts` with new contract name
+6. **Coordinated deployment**: Update frontend and announce to users
+7. **Monitor**: Track adoption and monitor for issues
+
+### 3. Configuration Management
+
+All contract references use centralized configuration:
+
+**Single source of truth**: `frontend/src/config.ts`
+
+```typescript
+export const CONTRACT_ADDRESS = 'SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T';
+export const CONTRACT_NAME = 'sprintfund-core';
+export const CONTRACT_PRINCIPAL = `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`;
+```
+
+All components import from this file instead of hardcoding values.
+
+### 4. Backward Compatibility
+
+For forward compatibility considerations:
+
+- **Contract traits**: Define interfaces for core functionality
+- **Version detection**: Frontend can detect contract version via read-only calls
+- **Graceful fallbacks**: Handle missing functions in older contracts
+- **State migration**: Plan data migration for breaking changes
+
+### 5. Testing Strategy
+
+Before switching to a new contract version:
+
+1. Deploy to devnet and run full test suite
+2. Deploy to testnet and perform manual QA
+3. Test migration path if applicable
+4. Verify all frontend components work with new contract
+5. Run security audit on changes
+6. Document any API changes
+
+## Version Switch Checklist
+
+When ready to switch to a new version:
+
+- [ ] Update `CONTRACT_NAME` in `frontend/src/config.ts`
+- [ ] Update `CONTRACT_NAME` in all script files under `scripts/`
+- [ ] Update documentation (README.md, frontend/README.md)
+- [ ] Update deployment configs (`Clarinet.toml`, deployment plans)
+- [ ] Update kubernetes configs if applicable
+- [ ] Test all functionality end-to-end
+- [ ] Update contract address in documentation
+- [ ] Announce to community with migration guide if needed
+
+## Current Status
+
+**Frontend is using**: `sprintfund-core` (v1)
+
+**Recommendation**: The v3 contract exists but is not in active use. Before switching:
+1. Document specific improvements in v3
+2. Test thoroughly
+3. Create migration plan if state needs to be preserved
+4. Update all references using the checklist above
+
+## Monitoring
+
+Track contract usage via:
+- Stacks Explorer: https://explorer.hiro.so/address/{CONTRACT_PRINCIPAL}
+- Contract read calls for version info
+- Transaction volume per contract
+
+## Contact
+
+For questions about contract versioning, open an issue on GitHub.

--- a/frontend/components/CreateProposalForm.tsx
+++ b/frontend/components/CreateProposalForm.tsx
@@ -9,6 +9,7 @@ import {
 } from '@stacks/transactions';
 import { toMicroSTX } from '@/utils/formatSTX';
 import { STACKS_MAINNET } from '@stacks/network';
+import { CONTRACT_ADDRESS, CONTRACT_NAME } from '@/config';
 import toast from 'react-hot-toast';
 import { motion, AnimatePresence } from 'framer-motion';
 import CategoryTags from './CategoryTags';
@@ -16,8 +17,6 @@ import { predictProposalSuccess } from '@/utils/successPredictor';
 import { Target, AlertCircle, Sparkles, Brain, CheckCircle2 } from 'lucide-react';
 import { useTransaction } from '@/hooks/useTransaction';
 
-const CONTRACT_ADDRESS = 'SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T';
-const CONTRACT_NAME = 'sprintfund-core';
 const NETWORK = STACKS_MAINNET;
 
 interface CreateProposalFormProps {

--- a/frontend/components/ExecuteProposal.tsx
+++ b/frontend/components/ExecuteProposal.tsx
@@ -7,10 +7,9 @@ import {
     uintCV,
 } from '@stacks/transactions';
 import { STACKS_MAINNET } from '@stacks/network';
+import { CONTRACT_ADDRESS, CONTRACT_NAME } from '@/config';
 import { useTransaction } from '@/hooks/useTransaction';
 
-const CONTRACT_ADDRESS = 'SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T';
-const CONTRACT_NAME = 'sprintfund-core';
 const NETWORK = STACKS_MAINNET;
 
 interface ExecuteProposalProps {

--- a/frontend/components/ProposalList.tsx
+++ b/frontend/components/ProposalList.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { fetchCallReadOnlyFunction, cvToValue, uintCV, boolCV, principalCV, AnchorMode, PostConditionMode } from '@stacks/transactions';
 import { STACKS_MAINNET } from '@stacks/network';
 import { formatSTX } from '@/utils/formatSTX';
+import { CONTRACT_ADDRESS, CONTRACT_NAME } from '@/config';
 import ExecuteProposal from './ExecuteProposal';
 import LoadingSkeleton from './LoadingSkeleton';
 import toast from 'react-hot-toast';
@@ -17,8 +18,6 @@ import { useNextProposalFilters } from '../hooks/useNextProposalFilters';
 import { useTransaction } from '@/hooks/useTransaction';
 import { useRefreshOnConfirmation } from '@/hooks/useRefreshOnConfirmation';
 
-const CONTRACT_ADDRESS = 'SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T';
-const CONTRACT_NAME = 'sprintfund-core';
 const NETWORK = STACKS_MAINNET;
 
 interface Proposal {

--- a/frontend/components/Stats.tsx
+++ b/frontend/components/Stats.tsx
@@ -4,9 +4,8 @@ import { useState, useEffect } from 'react';
 import { fetchCallReadOnlyFunction, cvToValue, uintCV } from '@stacks/transactions';
 import { STACKS_MAINNET } from '@stacks/network';
 import { formatSTX } from '@/utils/formatSTX';
+import { CONTRACT_ADDRESS, CONTRACT_NAME } from '@/config';
 
-const CONTRACT_ADDRESS = 'SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T';
-const CONTRACT_NAME = 'sprintfund-core';
 const NETWORK = STACKS_MAINNET;
 
 interface Proposal {

--- a/frontend/components/UserDashboard.tsx
+++ b/frontend/components/UserDashboard.tsx
@@ -4,10 +4,9 @@ import { useState, useEffect } from 'react';
 import { fetchCallReadOnlyFunction, cvToValue, principalCV, uintCV } from '@stacks/transactions';
 import { STACKS_MAINNET } from '@stacks/network';
 import { formatSTX } from '@/utils/formatSTX';
+import { CONTRACT_ADDRESS, CONTRACT_NAME } from '@/config';
 import VoteDelegation from './VoteDelegation';
 
-const CONTRACT_ADDRESS = 'SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T';
-const CONTRACT_NAME = 'sprintfund-core';
 const NETWORK = STACKS_MAINNET;
 
 interface UserDashboardProps {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import type { UserSession, UserData } from '@stacks/connect';
+import { CONTRACT_PRINCIPAL } from '@/config';
 import SprintFundHero from '@/components/ui/SprintFundHero';
 import CreateProposalForm from '@/components/CreateProposalForm';
 import ProposalList from '@/components/ProposalList';
@@ -13,8 +14,6 @@ import ErrorBoundary from '@/components/ErrorBoundary';
 import { LoadingSpinner, LoadingOverlay } from '@/components/LoadingIndicators';
 import { createLoadingState, updateLoadingState } from '@/lib/loading-state';
 import type { LoadingState } from '@/lib/loading-state';
-
-const CONTRACT_ADDRESS = 'SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T.sprintfund-core';
 
 type StacksUserData = UserData;
 
@@ -98,7 +97,7 @@ export default function Home() {
 
   const copyContractAddress = async () => {
     try {
-      await navigator.clipboard.writeText(CONTRACT_ADDRESS);
+      await navigator.clipboard.writeText(CONTRACT_PRINCIPAL);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1500);
     } catch (error) {
@@ -131,7 +130,7 @@ export default function Home() {
             <div className="inline-block bg-slate-800 rounded-lg px-6 py-3 border border-slate-700">
               <p className="text-sm text-slate-300 mb-1">Contract Address</p>
               <code className="text-white font-mono text-sm break-all">
-                {CONTRACT_ADDRESS}
+                {CONTRACT_PRINCIPAL}
               </code>
             </div>
           </div>
@@ -205,7 +204,7 @@ export default function Home() {
                 <h4 className="text-xs font-bold uppercase tracking-widest text-slate-400 mb-3">Contract</h4>
                 <div className="rounded-lg border border-slate-700 bg-slate-900/70 p-3">
                   <p className="text-[11px] text-slate-400 mb-1">Mainnet Contract Address</p>
-                  <code className="text-xs text-slate-200 break-all">{CONTRACT_ADDRESS}</code>
+                  <code className="text-xs text-slate-200 break-all">{CONTRACT_PRINCIPAL}</code>
                   <button
                     type="button"
                     onClick={copyContractAddress}

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,7 +1,7 @@
 /* ── Contract ─────────────────────────────────── */
 
 export const CONTRACT_ADDRESS = 'SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T';
-export const CONTRACT_NAME = 'sprintfund-core-v3';
+export const CONTRACT_NAME = 'sprintfund-core';
 export const CONTRACT_PRINCIPAL = `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`;
 export const NETWORK = 'mainnet' as const;
 

--- a/frontend/src/services/governance-analytics.ts
+++ b/frontend/src/services/governance-analytics.ts
@@ -5,9 +5,8 @@ import {
   principalCV,
 } from '@stacks/transactions';
 import { STACKS_MAINNET } from '@stacks/network';
+import { CONTRACT_ADDRESS, CONTRACT_NAME } from '../config';
 
-const CONTRACT_ADDRESS = 'SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T';
-const CONTRACT_NAME = 'sprintfund-core-v3';
 const NETWORK = STACKS_MAINNET;
 
 interface Proposal {

--- a/frontend/utils/analytics/dataCollector.ts
+++ b/frontend/utils/analytics/dataCollector.ts
@@ -1,9 +1,8 @@
 import { fetchCallReadOnlyFunction, cvToValue, uintCV } from '@stacks/transactions';
 import { STACKS_MAINNET } from '@stacks/network';
 import { retryTransaction } from '../retry';
+import { CONTRACT_ADDRESS, CONTRACT_NAME } from '@/config';
 
-const CONTRACT_ADDRESS = 'SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T';
-const CONTRACT_NAME = 'sprintfund-core';
 const NETWORK = STACKS_MAINNET;
 const CACHE_TTL = 5 * 60 * 1000;
 const CACHE_KEY_PREFIX = 'sprintfund_analytics_';


### PR DESCRIPTION
- Add CONTRACT_VERSIONS.md documenting deployed contracts and versioning strategy
- Fix config.ts to use sprintfund-core (active production contract)
- Centralize contract references in frontend/src/config.ts
- Update all components to import CONTRACT_ADDRESS and CONTRACT_NAME from config
- Remove hardcoded contract addresses from individual components
- Ensure consistency between frontend code and deployed contract

Created branch fix/contract-versioning-strategy with:

CONTRACT_VERSIONS.md: Documents all deployed contracts, versioning strategy, and migration checklist
Centralized config: All components now import from frontend/src/config.ts
Fixed inconsistency: Changed config.ts from sprintfund-core-v3 to sprintfund-core (active contract)
Updated 9 files to use centralized imports instead of hardcoded values

Closes #83 