### PR TITLE
Eliminate redundant API calls with centralized caching

### DIFF
--- a/frontend/components/ProposalList.tsx
+++ b/frontend/components/ProposalList.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { fetchCallReadOnlyFunction, cvToValue, uintCV, boolCV, principalCV, AnchorMode, PostConditionMode } from '@stacks/transactions';
-import { STACKS_MAINNET } from '@stacks/network';
+import { boolCV, uintCV } from '@stacks/transactions';
+import { getAllProposals, getStake, callVote } from '@/lib/stacks';
 import { formatSTX } from '@/utils/formatSTX';
-import { CONTRACT_ADDRESS, CONTRACT_NAME } from '@/config';
 import ExecuteProposal from './ExecuteProposal';
 import LoadingSkeleton from './ui/LoadingSkeleton';
 import toast from 'react-hot-toast';
@@ -17,23 +16,13 @@ import CategoryBadge from './CategoryBadge';
 import { useNextProposalFilters } from '../hooks/useNextProposalFilters';
 import { useTransaction } from '@/hooks/useTransaction';
 import { useRefreshOnConfirmation } from '@/hooks/useRefreshOnConfirmation';
+import type { Proposal } from '@/types';
 
-const NETWORK = STACKS_MAINNET;
-
-interface Proposal {
-    id: number;
-    proposer: string;
-    amount: number;
-    title: string;
-    description: string;
-    votesFor: number;
-    votesAgainst: number;
-    executed: boolean;
-    createdAt: number;
-    category?: string;
+interface ProposalListProps {
+    userAddress?: string;
 }
 
-export default function ProposalList({ userAddress }: { userAddress?: string }) {
+export default function ProposalList({ userAddress }: ProposalListProps) {
     const [proposals, setProposals] = useState<Proposal[]>([]);
     const [loading, setLoading] = useState(true);
     const [stakeLoading, setStakeLoading] = useState(false);
@@ -64,32 +53,8 @@ export default function ProposalList({ userAddress }: { userAddress?: string }) 
 
             try {
                 setStakeLoading(true);
-                const result = await fetchCallReadOnlyFunction({
-                    network: NETWORK,
-                    contractAddress: CONTRACT_ADDRESS,
-                    contractName: CONTRACT_NAME,
-                    functionName: 'get-stake',
-                    functionArgs: [principalCV(userAddress)],
-                    senderAddress: CONTRACT_ADDRESS,
-                });
-
-                const stakeValue = cvToValue(result) as Record<string, unknown> | number | null;
-                if (typeof stakeValue === 'number') {
-                    setUserStakeAmount(stakeValue);
-                    return;
-                }
-
-                const amount = typeof stakeValue === 'object' && stakeValue !== null
-                    ? (stakeValue.amount as Record<string, unknown> | number | undefined)
-                    : undefined;
-
-                if (typeof amount === 'number') {
-                    setUserStakeAmount(amount);
-                } else if (typeof amount === 'object' && amount !== null && 'value' in amount) {
-                    setUserStakeAmount(Number(amount.value) || 0);
-                } else {
-                    setUserStakeAmount(0);
-                }
+                const stake = await getStake(userAddress);
+                setUserStakeAmount(stake);
             } catch (err: unknown) {
                 console.error('Error fetching user stake:', err);
                 setUserStakeAmount(0);
@@ -106,60 +71,8 @@ export default function ProposalList({ userAddress }: { userAddress?: string }) 
             setLoading(true);
             setError('');
 
-            const countResult = await fetchCallReadOnlyFunction({
-                network: NETWORK,
-                contractAddress: CONTRACT_ADDRESS,
-                contractName: CONTRACT_NAME,
-                functionName: 'get-proposal-count',
-                functionArgs: [],
-                senderAddress: CONTRACT_ADDRESS,
-            });
-
-            const countValue = cvToValue(countResult);
-            const count = typeof countValue === 'number' ? countValue : (countValue?.value || 0);
-
-            if (count === 0) {
-                setProposals([]);
-                setLoading(false);
-                return;
-            }
-
-            const proposalPromises = [];
-            for (let i = 0; i < count; i++) {
-                proposalPromises.push(
-                    fetchCallReadOnlyFunction({
-                        network: NETWORK,
-                        contractAddress: CONTRACT_ADDRESS,
-                        contractName: CONTRACT_NAME,
-                        functionName: 'get-proposal',
-                        functionArgs: [uintCV(i)],
-                        senderAddress: CONTRACT_ADDRESS,
-                    })
-                );
-            }
-
-            const proposalResults = await Promise.all(proposalPromises);
-
-            const fetchedProposals: Proposal[] = proposalResults
-                .map((result, index) => {
-                    const proposalValue = cvToValue(result);
-                    if (proposalValue) {
-                        return {
-                            id: index,
-                            proposer: proposalValue.proposer?.value || proposalValue.proposer,
-                            amount: parseInt(proposalValue.amount?.value || proposalValue.amount),
-                            title: proposalValue.title?.value || proposalValue.title,
-                            description: proposalValue.description?.value || proposalValue.description,
-                            votesFor: parseInt(proposalValue['votes-for']?.value || proposalValue['votes-for']),
-                            votesAgainst: parseInt(proposalValue['votes-against']?.value || proposalValue['votes-against']),
-                            executed: proposalValue.executed?.value ?? proposalValue.executed,
-                            createdAt: parseInt(proposalValue['created-at']?.value || proposalValue['created-at']),
-                        };
-                    }
-                    return null;
-                })
-                .filter((p): p is Proposal => p !== null);
-
+            // Use centralized API with caching
+            const fetchedProposals = await getAllProposals();
             setProposals(fetchedProposals);
             setLoading(false);
         } catch (err: unknown) {

--- a/frontend/components/Stats.tsx
+++ b/frontend/components/Stats.tsx
@@ -1,19 +1,9 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { fetchCallReadOnlyFunction, cvToValue, uintCV } from '@stacks/transactions';
-import { STACKS_MAINNET } from '@stacks/network';
+import { getAllProposals, getProposalCount } from '@/lib/stacks';
 import { formatSTX } from '@/utils/formatSTX';
-import { CONTRACT_ADDRESS, CONTRACT_NAME } from '@/config';
-
-const NETWORK = STACKS_MAINNET;
-
-interface Proposal {
-    id: number;
-    proposer: string;
-    amount: number;
-    executed: boolean;
-}
+import type { Proposal } from '@/types';
 
 export default function Stats() {
     const [totalProposals, setTotalProposals] = useState(0);
@@ -30,56 +20,28 @@ export default function Stats() {
         try {
             setLoading(true);
 
-            // Fetch total proposals
-            const countResult = await fetchCallReadOnlyFunction({
-                network: NETWORK,
-                contractAddress: CONTRACT_ADDRESS,
-                contractName: CONTRACT_NAME,
-                functionName: 'get-proposal-count',
-                functionArgs: [],
-                senderAddress: CONTRACT_ADDRESS,
-            });
+            // Use centralized API with caching
+            const [count, proposals] = await Promise.all([
+                getProposalCount(),
+                getAllProposals()
+            ]);
 
-            const countValue = cvToValue(countResult);
-            const count = typeof countValue === 'number' ? countValue : (countValue?.value || 0);
             setTotalProposals(count);
 
-            // Fetch all proposals to calculate stats
-            const proposals: Proposal[] = [];
+            // Calculate stats from cached proposals
             const proposerCounts: { [key: string]: number } = {};
             let distributed = 0;
             let active = 0;
 
-            for (let i = 0; i < count; i++) {
-                const proposalResult = await fetchCallReadOnlyFunction({
-                    network: NETWORK,
-                    contractAddress: CONTRACT_ADDRESS,
-                    contractName: CONTRACT_NAME,
-                    functionName: 'get-proposal',
-                    functionArgs: [uintCV(i)],
-                    senderAddress: CONTRACT_ADDRESS,
-                });
+            for (const proposal of proposals) {
+                // Count proposers
+                proposerCounts[proposal.proposer] = (proposerCounts[proposal.proposer] || 0) + 1;
 
-                const proposalValue = cvToValue(proposalResult);
-                if (proposalValue) {
-                    const proposalData = {
-                        id: i,
-                        proposer: proposalValue.proposer?.value || proposalValue.proposer,
-                        amount: parseInt(proposalValue.amount?.value || proposalValue.amount),
-                        executed: proposalValue.executed?.value ?? proposalValue.executed,
-                    };
-
-                    proposals.push(proposalData);
-
-                    // Count proposers
-                    proposerCounts[proposalData.proposer] = (proposerCounts[proposalData.proposer] || 0) + 1;
-
-                    // Calculate distributed STX
-                    if (proposalData.executed) {
-                        distributed += proposalData.amount;
-                    } else {
-                        active++;
-                    }
+                // Calculate distributed STX
+                if (proposal.executed) {
+                    distributed += proposal.amount;
+                } else {
+                    active++;
                 }
             }
 

--- a/frontend/components/UserDashboard.tsx
+++ b/frontend/components/UserDashboard.tsx
@@ -1,13 +1,9 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { fetchCallReadOnlyFunction, cvToValue, principalCV, uintCV } from '@stacks/transactions';
-import { STACKS_MAINNET } from '@stacks/network';
+import { getStake, getAllProposals } from '@/lib/stacks';
 import { formatSTX } from '@/utils/formatSTX';
-import { CONTRACT_ADDRESS, CONTRACT_NAME } from '@/config';
 import VoteDelegation from './VoteDelegation';
-
-const NETWORK = STACKS_MAINNET;
 
 interface UserDashboardProps {
     userAddress?: string;
@@ -31,55 +27,18 @@ export default function UserDashboard({ userAddress }: UserDashboardProps) {
         try {
             setLoading(true);
 
-            // Fetch stake balance
-            const stakeResult = await fetchCallReadOnlyFunction({
-                network: NETWORK,
-                contractAddress: CONTRACT_ADDRESS,
-                contractName: CONTRACT_NAME,
-                functionName: 'get-stake',
-                functionArgs: [principalCV(userAddress)],
-                senderAddress: CONTRACT_ADDRESS,
-            });
+            // Use centralized API with caching
+            const [stake, proposals] = await Promise.all([
+                getStake(userAddress),
+                getAllProposals()
+            ]);
 
-            const stakeValue = cvToValue(stakeResult);
-            if (stakeValue) {
-                const amount = stakeValue.amount?.value || stakeValue.amount;
-                setStakeBalance(parseInt(amount));
-            }
+            setStakeBalance(stake);
 
-            // Fetch proposal count to iterate through all proposals
-            const countResult = await fetchCallReadOnlyFunction({
-                network: NETWORK,
-                contractAddress: CONTRACT_ADDRESS,
-                contractName: CONTRACT_NAME,
-                functionName: 'get-proposal-count',
-                functionArgs: [],
-                senderAddress: CONTRACT_ADDRESS,
-            });
-
-            const countValue = cvToValue(countResult);
-            const count = typeof countValue === 'number' ? countValue : (countValue?.value || 0);
-
-            // Fetch all proposals and filter user's proposals
-            const userProposalIds: number[] = [];
-            for (let i = 0; i < count; i++) {
-                const proposalResult = await fetchCallReadOnlyFunction({
-                    network: NETWORK,
-                    contractAddress: CONTRACT_ADDRESS,
-                    contractName: CONTRACT_NAME,
-                    functionName: 'get-proposal',
-                    functionArgs: [uintCV(i)],
-                    senderAddress: CONTRACT_ADDRESS,
-                });
-
-                const proposalValue = cvToValue(proposalResult);
-                if (proposalValue) {
-                    const proposer = proposalValue.proposer?.value || proposalValue.proposer;
-                    if (proposer === userAddress) {
-                        userProposalIds.push(i);
-                    }
-                }
-            }
+            // Filter user's proposals from cached data
+            const userProposalIds = proposals
+                .filter(p => p.proposer === userAddress)
+                .map(p => p.id);
 
             setMyProposals(userProposalIds);
             setLoading(false);


### PR DESCRIPTION
## Summary
Refactors legacy components to use centralized API layer with blockchain caching.

## Changes
- Stats.tsx: Now uses getAllProposals and getProposalCount from stacks.ts
- UserDashboard.tsx: Now uses getStake and getAllProposals
- ProposalList.tsx: Now uses centralized stacks.ts API

## Impact
- Reduces API calls from 3x to 1x for shared data
- Uses existing blockchainCache for automatic deduplication
- Improves page load performance

Closes #95