### PR TITLE
Add environment-based network configuration

### DIFF
--- a/NETWORK_CONFIG.md
+++ b/NETWORK_CONFIG.md
@@ -1,0 +1,92 @@
+# Network Configuration
+
+SprintFund supports both Stacks Mainnet and Testnet environments via environment variables.
+
+## Quick Start
+
+1. Copy `.env.example` to `.env.local`:
+   ```bash
+   cp .env.example .env.local
+   ```
+
+2. Edit `.env.local` to set your network:
+   ```bash
+   NEXT_PUBLIC_NETWORK=mainnet  # or testnet
+   NEXT_PUBLIC_CONTRACT_ADDRESS=SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T
+   ```
+
+## Environment Variables
+
+### `NEXT_PUBLIC_NETWORK`
+- **Type:** `mainnet` | `testnet`
+- **Default:** `mainnet`
+- **Description:** Determines which Stacks network to connect to
+
+### `NEXT_PUBLIC_CONTRACT_ADDRESS`
+- **Type:** String (Stacks address)
+- **Default:** `SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T` (mainnet)
+- **Description:** The deployed contract address for your network
+
+### `NEXT_PUBLIC_CONTRACT_NAME`
+- **Type:** String
+- **Default:** `sprintfund-core`
+- **Description:** The contract name (optional)
+
+### `NEXT_PUBLIC_STACKS_API_URL`
+- **Type:** URL string
+- **Default:** Auto-selected based on `NEXT_PUBLIC_NETWORK`
+  - Mainnet: `https://stacks-node-api.mainnet.stacks.co`
+  - Testnet: `https://stacks-node-api.testnet.stacks.co`
+- **Description:** Stacks API endpoint (optional override)
+
+## Network Presets
+
+### Mainnet (Production)
+```bash
+NEXT_PUBLIC_NETWORK=mainnet
+NEXT_PUBLIC_CONTRACT_ADDRESS=SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T
+NEXT_PUBLIC_CONTRACT_NAME=sprintfund-core
+```
+
+### Testnet (Development)
+```bash
+NEXT_PUBLIC_NETWORK=testnet
+NEXT_PUBLIC_CONTRACT_ADDRESS=ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+NEXT_PUBLIC_CONTRACT_NAME=sprintfund-core
+```
+
+## Testing Network Switching
+
+To test network configuration:
+
+```bash
+# Test mainnet
+NEXT_PUBLIC_NETWORK=mainnet npm run dev
+
+# Test testnet
+NEXT_PUBLIC_NETWORK=testnet npm run dev
+```
+
+## Implementation Details
+
+The network configuration is centralized in `src/config.ts`:
+- All network-specific settings are derived from `NEXT_PUBLIC_NETWORK`
+- API URLs auto-select based on network
+- Contract address can be overridden per environment
+- No code changes needed to switch networks
+
+## Deployment
+
+For production deployments, create `.env.production.local`:
+```bash
+cp .env.production .env.production.local
+# Edit with your production values
+```
+
+For staging deployments, use `.env.staging.local`:
+```bash
+cp .env.staging .env.staging.local
+# Edit with your staging values
+```
+
+**Never commit `.env.*.local` files to version control.**

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -11,5 +11,14 @@ NEXT_PUBLIC_NETWORK=mainnet
 # Deployed contract address
 NEXT_PUBLIC_CONTRACT_ADDRESS=SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T
 
-# Stacks API base URL
+# Contract name (optional, defaults to sprintfund-core)
+NEXT_PUBLIC_CONTRACT_NAME=sprintfund-core
+
+# Stacks API base URL (optional, auto-selected based on network)
 NEXT_PUBLIC_STACKS_API_URL=https://stacks-node-api.mainnet.stacks.co
+
+# For testnet development, use:
+# NEXT_PUBLIC_NETWORK=testnet
+# NEXT_PUBLIC_CONTRACT_ADDRESS=ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+# NEXT_PUBLIC_STACKS_API_URL=https://stacks-node-api.testnet.stacks.co
+

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,14 +1,24 @@
 /* ── Contract ─────────────────────────────────── */
 
-export const CONTRACT_ADDRESS = 'SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T';
-export const CONTRACT_NAME = 'sprintfund-core';
+export const NETWORK = (process.env.NEXT_PUBLIC_NETWORK || 'mainnet') as 'mainnet' | 'testnet';
+export const CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS || 'SP31PKQVQZVZCK3FM3NH67CGD6G1FMR17VQVS2W5T';
+export const CONTRACT_NAME = process.env.NEXT_PUBLIC_CONTRACT_NAME || 'sprintfund-core';
 export const CONTRACT_PRINCIPAL = `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`;
-export const NETWORK = 'mainnet' as const;
 
 /* ── API ──────────────────────────────────────── */
 
-export const API_URL = 'https://api.mainnet.hiro.so';
-export const EXPLORER_URL = 'https://explorer.hiro.so';
+const API_URLS = {
+  mainnet: 'https://api.mainnet.hiro.so',
+  testnet: 'https://api.testnet.hiro.so',
+} as const;
+
+const EXPLORER_URLS = {
+  mainnet: 'https://explorer.hiro.so',
+  testnet: 'https://explorer.hiro.so', 
+} as const;
+
+export const API_URL = process.env.NEXT_PUBLIC_STACKS_API_URL || API_URLS[NETWORK];
+export const EXPLORER_URL = EXPLORER_URLS[NETWORK];
 
 /* ── STX conversions ──────────────────────────── */
 


### PR DESCRIPTION
Fixes #32

**Changes:**
- Network now read from `NEXT_PUBLIC_NETWORK` env var
- Contract address configurable via `NEXT_PUBLIC_CONTRACT_ADDRESS`
- API URLs auto-selected based on network
- Added comprehensive NETWORK_CONFIG.md guide
- Updated .env.example with testnet example

**Benefits:**
- Switch mainnet/testnet without code changes
- Set up via .env.local file
- Ready for deployment environments