### PR TITLE
fix(cache): clear min stake entries during invalidate-all

### DIFF
--- a/frontend/src/lib/blockchain-cache.ts
+++ b/frontend/src/lib/blockchain-cache.ts
@@ -134,6 +134,7 @@ class BlockchainDataCache {
     this.proposalPages.clear();
     this.proposalCounts.clear();
     this.stakes.clear();
+    this.minStakeAmounts.clear();
   }
 
   getStats(): CacheStats {


### PR DESCRIPTION
Include minStakeAmounts in full cache invalidation so size accounting and invalidateAll behavior remain consistent.